### PR TITLE
use dataset/recover

### DIFF
--- a/gfw_country_pages_analysis_2/utilities/api.py
+++ b/gfw_country_pages_analysis_2/utilities/api.py
@@ -67,13 +67,13 @@ def overwrite_dataset(headers, api_url, dataset_id, s3_url):
     if status != "saved":
 
         log.warning(
-            'There was an issue while updating dataset "{}". Dataset with id {} not in saved status. Reset status.'.format(
+            'There was an issue while updating dataset "{}". Dataset with id {} not in saved status. Recover dataset.'.format(
                 name, dataset_id
             ),
             True,
             dataset_id,
         )
-        _patch_status(headers, dataset_url)
+        _recover(headers, dataset_url)
 
     _overwrite_dataset(headers, dataset_url, s3_url, name)
 
@@ -97,9 +97,10 @@ def _patch_overwrite(headers, dataset_url):
     make_request(headers, dataset_url, "PATCH", modify_attributes_payload, 200)
 
 
-def _patch_status(headers, dataset_url):
-    modify_attributes_payload = {"status": "saved"}
-    make_request(headers, dataset_url, "PATCH", modify_attributes_payload, 200)
+def _recover(headers, dataset_url):
+    make_request(
+        headers, "{}/recover".format(dataset_url), "POST", status_code_required=200
+    )
 
 
 def _overwrite_dataset(headers, dataset_url, s3_url, name):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="gfw_country_pages_analysis_2",
-    version="1.0.7",
+    version="1.0.8",
     description="Tool to create summary tables for GFW country pages",
     author="Charlie Hoffman, Thomas Maschler",
     license="MIT",


### PR DESCRIPTION
Use new API feature dataset/recover instead of simply overwrite dataset status.
This makes sure that any possible errors are cleared in the API

Signed-off-by: Thomas Maschler <tmaschler@wri.org>